### PR TITLE
Feature/tests for cicd

### DIFF
--- a/src/geospatial_toolkit/latlong.py
+++ b/src/geospatial_toolkit/latlong.py
@@ -50,7 +50,7 @@ def standardize_latlong(lat, lon):
         """
         try:
             return float(coord)
-        except (ValueError):
+        except (ValueError, TypeError):
             pass
 
         if isinstance(coord, str):

--- a/tests/unit/test_calc_antipode.py
+++ b/tests/unit/test_calc_antipode.py
@@ -110,6 +110,14 @@ class TestGetAntipode:
         assert coords == (-10, -160)
         assert desc is None
 
+    def test_reverse_geocode_no_result(self, mock_geolocator):
+        # Test reverse geocode returns None leads to ocean identification.
+        mock_geolocator.reverse.return_value = None
+        coords, desc = get_antipode((45, 45))
+        
+        assert coords == (-45, -135)
+        assert desc == "Pacific Ocean"
+
 
 class TestIdentifyOcean:
     # Unit tests for _identify_ocean() - 5 major oceans.

--- a/tests/unit/test_calc_antipode.py
+++ b/tests/unit/test_calc_antipode.py
@@ -104,6 +104,11 @@ class TestGetAntipode:
         with pytest.raises(ValueError):
             get_antipode((0, 181))
 
+    def test_resolve_names_false(self):
+        # Test resolve_names=False returns None for description.
+        coords, desc = get_antipode((10, 20), resolve_names=False)
+        assert coords == (-10, -160)
+        assert desc is None
 
 
 class TestIdentifyOcean:

--- a/tests/unit/test_calc_antipode.py
+++ b/tests/unit/test_calc_antipode.py
@@ -110,13 +110,6 @@ class TestGetAntipode:
         assert coords == (-10, -160)
         assert desc is None
 
-    def test_reverse_geocode_no_result(self, mock_geolocator):
-        # Test reverse geocode returns None leads to ocean identification.
-        mock_geolocator.reverse.return_value = None
-        coords, desc = get_antipode((45, 45))
-        
-        assert coords == (-45, -135)
-        assert desc == "Pacific Ocean"
 
 
 class TestIdentifyOcean:

--- a/tests/unit/test_calc_antipode.py
+++ b/tests/unit/test_calc_antipode.py
@@ -105,6 +105,7 @@ class TestGetAntipode:
             get_antipode((0, 181))
 
 
+
 class TestIdentifyOcean:
     # Unit tests for _identify_ocean() - 5 major oceans.
     
@@ -127,3 +128,8 @@ class TestIdentifyOcean:
     def test_southern_ocean(self):
         # Antarctic waters: (-65, 0)
         assert _identify_ocean(-65, 0) == "Southern(Antarctic) Ocean"
+
+    def test_transition_zone_indian_to_pacific(self):
+        # lon between 100 and 145 AND lat < -10
+        assert _identify_ocean(-20, 120) == "Indian Ocean"
+

--- a/tests/unit/test_standardize_latlong.py
+++ b/tests/unit/test_standardize_latlong.py
@@ -97,3 +97,18 @@ def test_standardize_latlong_mixed_formats(lat, lon, expected):
 
     assert result_lat == pytest.approx(expected[0], abs=1e-6)
     assert result_lon == pytest.approx(expected[1], abs=1e-6)
+
+def test_standardize_latlong_unrecognized_string():
+    """
+    Test that unrecognized string inputs raise ValueError.
+    """
+    with pytest.raises(ValueError, match="Input format not recognized or invalid"):
+        standardize_latlong("wrong", "also wrong")
+
+
+def test_standardize_latlong_non_string_non_float():
+    """
+    Test that non-string, non-float inputs raise ValueError.
+    """
+    with pytest.raises(ValueError, match="Input format not recognized or invalid"):
+        standardize_latlong([34.0], {118.0})

--- a/tests/unit/test_standardize_latlong.py
+++ b/tests/unit/test_standardize_latlong.py
@@ -80,3 +80,20 @@ def test_standardize_latlong_invalid_format(lat, lon):
     """
     with pytest.raises(ValueError, match="Input format not recognized or invalid"):
         standardize_latlong(lat, lon)
+
+# Test mixed coordinate formats
+
+@pytest.mark.parametrize("lat, lon, expected", [
+    (34.0522, "118°14'37\"W", (34.0522, -118.243611)),
+    ("34°3'8\"N", -118.2437, (34.052222, -118.2437)),
+    ("34°3.133'N", "118°14'37\"W", (34.052217, -118.243611)),
+    ("34°3'8\"N", "118°14.617'W", (34.052222, -118.243617)),
+])
+def test_standardize_latlong_mixed_formats(lat, lon, expected):
+    """
+    Test that mixed format latitude/longitude inputs are converted correctly.
+    """
+    result_lat, result_lon = standardize_latlong(lat, lon)
+
+    assert result_lat == pytest.approx(expected[0], abs=1e-6)
+    assert result_lon == pytest.approx(expected[1], abs=1e-6)


### PR DESCRIPTION
- [x] fix #52
- [x] description of feature/fix
 Added tests to test_calc_antipode.py and test_standardize_latlong.py
- [x] tests added/passed
  - [x] test_calc_antipode.py (currently at 95% test coverage)
     - [x] test_transition_zone_indian_to_pacific()
     - [x] test_resolve_names_false()
   - [x] test_standardize_latlong.py (currently at 100% test coverage)
     - [x] test_standardize_latlong_mixed_formats()
     - [x] test_standardize_latlong_unrecognized_string()
     - [x] test_standardize_latlong_non_string_non_float()
 - [x] Updated parse_coordinates() function in latlong.py to catch TypeError for non-numeric inputs. test_standardize_latlong_non_string_non_float() was failing before the update.
  
