### PR TITLE
Feature/dev dependencies projtoml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ Download = "https://pypi.org/project/geospatial-toolkit/#files"
 dev = [
     "hatch",
     "pre-commit",
+    "ruff",
+    "black",
+    "quartodoc",
 ]
 
 docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,21 @@ tests = [
     "pytest-xdist",
 ]
 
+all = [
+    "hatch",
+    "pre-commit",
+    "ruff",
+    "black",
+    "quartodoc",
+    "pip-audit",
+    "twine",
+    "pytest",
+    "pytest-cov",
+    "pytest-raises",
+    "pytest-randomly",
+    "pytest-xdist",
+]
+
 
 ################################################################################
 # Tool Configuration


### PR DESCRIPTION
- [x] fix #57 
- [x] Optional dependencies does not include black, quartodoc, ruff - added to dev dependencies
- [x] Made a combined section 'all' to include all docs, dev, tests dependencies so that it's easy for contributors to install along with the package.
