### PR TITLE
ci(docs): add Netlify deployment for PR previews

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,3 +28,16 @@ jobs:
       - name: Build documentation using Hatch
         run: |
             hatch run docs:build
+
+      - name: Deploy to Netlify
+        uses: nwtgck/actions-netlify@v3
+        with:
+          publish-dir: './docs'
+          production-deploy: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deploy-message: "Deploy from GitHub Actions - ${{ github.event_name }}"
+          enable-pull-request-comment: true
+          enable-commit-comment: false
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}


### PR DESCRIPTION
- Deploy to Netlify on PR and push to main
- Enable PR comment with preview URL
- Production deploy only on push to main

- [x] fix #77

